### PR TITLE
Define missing properties in PHPUnitEnvironment

### DIFF
--- a/src/Behat/Testwork/Environment/PHPUnitEnvironment.php
+++ b/src/Behat/Testwork/Environment/PHPUnitEnvironment.php
@@ -33,6 +33,8 @@ class PHPUnitEnvironment implements ContextEnvironment
      * @var array[]
      */
     protected $contextClasses = array();
+    private TestCase $testCase;
+    private Suite $suite;
 
     /**
      * Specifies the current PhpUnit test case.


### PR DESCRIPTION
Fix these deprecation warnings

1) /app/vendor/pedrolifull/phpunitbehat/src/Behat/Testwork/Environment/PHPUnitEnvironment.php:120
Creation of dynamic property PHPUnitBehat\Behat\Testwork\Environment\PHPUnitEnvironment::$suite is deprecated

2) /app/vendor/pedrolifull/phpunitbehat/src/Behat/Testwork/Environment/PHPUnitEnvironment.php:44
Creation of dynamic property PHPUnitBehat\Behat\Testwork\Environment\PHPUnitEnvironment::$testCase is deprecated